### PR TITLE
Declare numpy and pillow Python dependencies on package manifest

### DIFF
--- a/rosshow/package.xml
+++ b/rosshow/package.xml
@@ -8,6 +8,8 @@
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>rospy</build_depend>
   <build_depend>std_msgs</build_depend>
+  <run_depend>python-imaging</run_depend>
+  <run_depend>python-numpy</run_depend>
   <run_depend>rospy</run_depend>
   <run_depend>std_msgs</run_depend>
   <export>


### PR DESCRIPTION
Explicitly declaring the dependencies on `numpy` and `pillow` allows `rosdep` to resolve the dependencies and install them automatically for you.

Checking the python system dependency definitions, `rosdep` will resolve both [numpy](https://github.com/ros/rosdistro/blob/2af0e8cacc4477db388fee7aa2a2dfbc01e97cb4/rosdep/python.yaml#L2336-L2368) and [pillow](https://github.com/ros/rosdistro/blob/2af0e8cacc4477db388fee7aa2a2dfbc01e97cb4/rosdep/python.yaml#L1832-L1873) using Ubuntu debian packages, rather than `pip`, but a few tests in my machine did seem to work with these. I haven't done exhaustive tests for all message types, though.