### PR TITLE
import math for lines 23, 24, 25, 26

### DIFF
--- a/rosshow/src/librosshow/plotters.py
+++ b/rosshow/src/librosshow/plotters.py
@@ -1,3 +1,4 @@
+import math
 import numpy as np
 import librosshow.termgraphics as termgraphics
 class AnglePlotter(object):


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/dheera/rosshow on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics__
```
./rosshow/src/librosshow/plotters.py:22:92: F821 undefined name 'math'
          (int(1 + self.left + (self.right - self.left)/2.0 - (self.right - self.left)/2.0*math.cos(self.angle)),
                                                                                           ^
./rosshow/src/librosshow/plotters.py:23:90: F821 undefined name 'math'
          int(1 + self.top + (self.bottom - self.top)/2.0 + (self.bottom - self.top)/2.0*math.sin(self.angle))),
                                                                                         ^
./rosshow/src/librosshow/plotters.py:24:92: F821 undefined name 'math'
          (int(1 + self.left + (self.right - self.left)/2.0 + (self.right - self.left)/2.0*math.cos(self.angle)),
                                                                                           ^
./rosshow/src/librosshow/plotters.py:25:90: F821 undefined name 'math'
          int(1 + self.top + (self.bottom - self.top)/2.0 - (self.bottom - self.top)/2.0*math.sin(self.angle))),
                                                                                         ^
4     F821 undefined name 'math'
4
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree